### PR TITLE
unix: remove redundant chdir()

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -38,9 +38,6 @@ impl Daemonize {
         if let Some(umask) = self.umask {
             libc::umask(umask);
         }
-        if let Some(chdir) = &self.chdir {
-            set_current_dir(chdir).map_err(|_| "chdir() failed")?;
-        }
 
         let stdin_file = self.stdin_file.unwrap_or_else(|| "/dev/null".into());
         let fd = OpenOptions::new()


### PR DESCRIPTION
The directory change was redundant with the following one.

The only behaviour change is if `chroot` is `true` and we `chdir` to the specified directory before `chrooting` and `chdir`ing to the new root, but it seemed unnecessary ?