### PR TITLE
unix: append to stdout / stderr, don't write over

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -53,7 +53,7 @@ impl Daemonize {
         let stdout_file = self.stdout_file.unwrap_or_else(|| "/dev/null".into());
         let fd = OpenOptions::new()
             .create(true)
-            .write(true)
+            .append(true)
             .open(stdout_file)
             .map_err(|_| "Unable to open the stdout file")?;
         if libc::dup2(fd.as_raw_fd(), 1) == -1 {
@@ -62,7 +62,7 @@ impl Daemonize {
         let stderr_file = self.stderr_file.unwrap_or_else(|| "/dev/null".into());
         let fd = OpenOptions::new()
             .create(true)
-            .write(true)
+            .append(true)
             .open(stderr_file)
             .map_err(|_| "Unable to open the stderr file")?;
         if libc::dup2(fd.as_raw_fd(), 2) == -1 {


### PR DESCRIPTION
When piping `stdout` and `stderr` to a log file, opening the file descriptors
with `write(true)` instead of `append` would write over the previous log at next
startup.